### PR TITLE
ci: Automate version bump to v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "al-quantus-cli"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "al-quantus-cli"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 authors = ["Quantus Network"]
 license = "Apache-2.0"


### PR DESCRIPTION
Automated version bump for release v0.0.2.

https://github.com/aletheia-labs/quantus-cli/actions/runs/17786439615

Triggered by workflow run: patch

Type: 